### PR TITLE
ci: add PR checks workflow

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -1,0 +1,16 @@
+name: PR Checks
+on:
+  pull_request:
+permissions:
+  contents: read
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '11'
+          cache: maven
+      - run: ./mvnw -B -ntp verify


### PR DESCRIPTION
Adds a `pull_request`-triggered CI workflow so Dependabot PRs (and others) are built and tested.

- Runs on every pull request
- Sets up Java 11 (Temurin) with Maven cache
- Executes `./mvnw -B -ntp verify` using the project's Maven wrapper

🤖 Generated with [Claude Code](https://claude.com/claude-code)