### PR TITLE
deps: upgrade Quarkus platform from 2.7.1.Final to 3.37.2

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -11,6 +11,6 @@ jobs:
       - uses: actions/setup-java@v4
         with:
           distribution: temurin
-          java-version: '11'
+          java-version: '17'
           cache: maven
       - run: ./mvnw -B -ntp verify

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 #Maven
 target/
+.mvn/wrapper/maven-wrapper.jar
 pom.xml.tag
 pom.xml.releaseBackup
 pom.xml.versionsBackup

--- a/pom.xml
+++ b/pom.xml
@@ -9,12 +9,12 @@
     <properties>
         <compiler-plugin.version>3.15.0</compiler-plugin.version>
         <failsafe.useModulePath>false</failsafe.useModulePath>
-        <maven.compiler.release>11</maven.compiler.release>
+        <maven.compiler.release>17</maven.compiler.release>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
-        <quarkus.platform.version>2.7.1.Final</quarkus.platform.version>
+        <quarkus.platform.version>3.37.2</quarkus.platform.version>
         <surefire-plugin.version>3.6.0-M1</surefire-plugin.version>
     </properties>
     <dependencyManagement>
@@ -48,7 +48,7 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-junit5</artifactId>
+            <artifactId>quarkus-junit</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>


### PR DESCRIPTION
Migrate to Quarkus 3:
- Bump quarkus.platform.version to 3.37.2
- Raise maven.compiler.release to 17 (Quarkus 3 requires Java 17+)
- Rename quarkus-junit5 dependency to quarkus-junit (relocated in 3.x)
- Update CI workflow to build with Java 17

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_011SCYCT7zshh2GjYzSQUJ89